### PR TITLE
Fix background image path issues on Windows

### DIFF
--- a/app/src/controllers/home.coffee
+++ b/app/src/controllers/home.coffee
@@ -64,7 +64,8 @@ class Home extends Spine.Controller
   setBackgroundImage: (imagePath) ->
     body = $('body')
     imagePath = path.resolve(imagePath)
-    imageValue = "url('file://#{imagePath.replace(/\s/g, '%20')}')"
+    imagePath = imagePath.replace(/\\/g, '\\\\') if path.sep is '\\'
+    imageValue = "url('file://#{imagePath}')"
 
     return if body.css('background-image').replace(/'/g, '') == imageValue.replace(/'/g, '')
 


### PR DESCRIPTION
### hello there

Hello @maddox! i come in :v: ("peace", there's no peace emoji?). i've been lurking around looking at atom-shell-based repos for my programmer-play-time and seeing yours, it brought me back to fun times with MAME during college. So i've been playing around to try to get it going on my box.

:warning: i don't know what i'm doing when it comes to node/js/coffeescript/Spine/Atom etc... so please feel free to let me know if i'm completely missing things :smile:

:warning: i'm on a windows box too, so yeah, there's lots of wonky stuff going on, i may add more PRs to help other windows people like me.
### skip to here for actual PR content

This fixes the file URL on a windows machine. i was getting:

![noimage](https://cloud.githubusercontent.com/assets/238079/3935178/cb1e6f0a-2492-11e4-8784-56796abd34a1.PNG)

and seeing `GET file:///C:/Usersjames_000ocumentssrckartppimages%0Bg-texture.png` isn't fun.

This patch brings that nice background back to me.
