### PR TITLE
Return a blank string instead of null

### DIFF
--- a/app/src/models/settings.coffee
+++ b/app/src/models/settings.coffee
@@ -11,7 +11,7 @@ class Settings extends Spine.Model
     window.localStorage.setItem(key, value)
 
   readSetting: (key) ->
-    window.localStorage.getItem(key)
+    window.localStorage.getItem(key) || ''
 
   retroarchPath: ->
     @readSetting('retroarchPath')


### PR DESCRIPTION
After fresh installing Kart on a Win7 machine, i had no settings input so testing for a custom background image path would throw a TypeError because path doesn't accept null arguments:

It would occur in [line 48 of the home controller](https://github.com/maddox/kart/blob/24a0b18f112b6c9f6e5ca80b7a45288ce9e4c760/app/src/controllers/home.coffee#L48):

``` coffee
custom_background_path = path.join(@settings.romsPath(), 'background.png')
```

This patch returns a string instead of a null for a setting if the setting isn't in local storage.
