### PR TITLE
Fix Background Flashing

### DIFF
--- a/app/src/controllers/home.coffee
+++ b/app/src/controllers/home.coffee
@@ -65,7 +65,7 @@ class Home extends Spine.Controller
     body = $('body')
     imagePath = path.resolve(imagePath)
     imagePath = imagePath.replace(/\\/g, '\\\\') if path.sep is '\\'
-    imageValue = "url('file://#{imagePath}')"
+    imageValue = "url('file://#{imagePath.replace(/\s/g, '%20')}')"
 
     return if body.css('background-image').replace(/'/g, '') == imageValue.replace(/'/g, '')
 


### PR DESCRIPTION
This adds back the space replacement in the custom background path. 

This was originally removed in 99b4cfefba87a46b73f3e2a92d0de49bf3a99b9b.

We need this for spaces in the file path. Without it, the background is
constantly replaced because the paths don’t match. This causes a flash
every time you get back to the home view, blegh.

This is especially a problem since Kart is designed to point at your
Dropbox dir, and if you have an org account your Dropbox dirs are split
in two with the names `Dropbox (Personal)` and `Dropbox (CompanyName)`.
