### PR TITLE
Fix Roms Path Setting

### DIFF
--- a/app/src/controllers/settings.coffee
+++ b/app/src/controllers/settings.coffee
@@ -11,7 +11,7 @@ class Settings extends Spine.Controller
   elements:
     '#retroarch_path': 'retroarchPathInput'
     '#roms_path': 'romsPathInput'
-    '#retro_mode': 'romsPathInput'
+    '#retro_mode': 'retroMode'
 
   events:
     'click #retroarch_path_button': 'browseRetroarchPath'


### PR DESCRIPTION
This fixes a bug where the roms path wasn't showing in the settings view.

![screen shot 2014-08-27 at 12 03 41 am](https://cloud.githubusercontent.com/assets/260/4055205/373c11e6-2d9f-11e4-8e74-4cb0a685efce.png)
