### PR TITLE
Steal coffee-cache from atom

### DIFF
--- a/app/coffee-cache.coffee
+++ b/app/coffee-cache.coffee
@@ -1,0 +1,44 @@
+crypto = require 'crypto'
+path = require 'path'
+
+CoffeeScript = require 'coffee-script'
+fs = require 'fs-plus'
+
+coffeeCacheDir = path.join(path.join(__dirname, 'coffee-cache'), 'coffee')
+
+getCachePath = (coffee) ->
+  digest = crypto.createHash('sha1').update(coffee, 'utf8').digest('hex')
+  path.join(coffeeCacheDir, "#{digest}.js")
+
+getCachedJavaScript = (cachePath) ->
+  if fs.isFileSync(cachePath)
+    try
+      fs.readFileSync(cachePath, 'utf8')
+
+convertFilePath = (filePath) ->
+  if process.platform is 'win32'
+    filePath = "/#{path.resolve(filePath).replace(/\\/g, '/')}"
+  encodeURI(filePath)
+
+compileCoffeeScript = (coffee, filePath, cachePath) ->
+  {js, v3SourceMap} = CoffeeScript.compile(coffee, filename: filePath, sourceMap: true)
+  # Include source map in the web page environment.
+  if btoa? and JSON? and unescape? and encodeURIComponent?
+    js = "#{js}\n//# sourceMappingURL=data:application/json;base64,#{btoa unescape encodeURIComponent v3SourceMap}\n//# sourceURL=#{convertFilePath(filePath)}"
+  try
+    fs.writeFileSync(cachePath, js)
+  js
+
+requireCoffeeScript = (module, filePath) ->
+  coffee = fs.readFileSync(filePath, 'utf8')
+  cachePath = getCachePath(coffee)
+  js = getCachedJavaScript(cachePath) ? compileCoffeeScript(coffee, filePath, cachePath)
+  module._compile(js, filePath)
+
+module.exports =
+  cacheDir: coffeeCacheDir
+  register: ->
+    Object.defineProperty(require.extensions, '.coffee', {
+      writable: false
+      value: requireCoffeeScript
+    })

--- a/app/index.html
+++ b/app/index.html
@@ -19,11 +19,7 @@
         module.paths.push(path.join(__dirname, 'node_modules'));
 
         require('coffee-script');
-        require('coffee-cache').setCacheDir(path.join(__dirname, 'coffee-cache'));
-        Object.defineProperty(require.extensions, '.coffee', {
-          writable: false,
-          value: require.extensions['.coffee']
-        });
+        require('coffee-cache').register();
         require('app');
       }
       catch (error) {

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,6 @@
   "main": "./main.js",
   "dependencies": {
     "async": "0.2.6",
-    "coffee-cache": "~0.2.0",
     "coffee-script": "~1.6.3",
     "eco": "~1.0",
     "font-awesome": "4.0.3",


### PR DESCRIPTION
This lets us see the original coffeescript source files while debugging in the developer tools, not just the js generated by the coffeescript source.

Not sure if this is something you want... i just noticed it while messing with some atom language tests and thought it might be a good addition. Although, since i dont know coffeescript, it's kinda nice to see the js that gets generated... the more i'm typing the less sure i am about creating this PR.
