### PR TITLE
atom-shell => electron

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -24,10 +24,10 @@ module.exports = (grunt) ->
           force: true
           overwrite: true
 
-    'download-atom-shell':
+    'download-electron':
       version: packageJson.atomShellVersion
-      outputDir: path.join('atom-shell')
-      downloadDir: path.join(os.tmpdir(), 'downloaded-atom-shell')
+      outputDir: path.join('electron')
+      downloadDir: path.join(os.tmpdir(), 'downloaded-electron')
       rebuild: true  # rebuild native modules after atom-shell is updated
 
     shell:
@@ -48,9 +48,9 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-symbolic-link')
   grunt.loadNpmTasks('grunt-shell')
-  grunt.loadNpmTasks('grunt-download-atom-shell')
+  grunt.loadNpmTasks('grunt-download-electron')
   grunt.loadTasks('tasks')
 
-  grunt.registerTask('bootstrap', ['download-atom-shell', 'symlink:app', 'generate-plist', 'shell:app-apm-install'])
-  grunt.registerTask('bootstrap-win', ['download-atom-shell', 'shell:app-apm-install'])
-  grunt.registerTask('build', ['download-atom-shell', 'shell:app-apm-install', 'copy:app', 'generate-plist'])
+  grunt.registerTask('bootstrap', ['grunt-download-electron', 'symlink:app', 'generate-plist', 'shell:app-apm-install'])
+  grunt.registerTask('bootstrap-win', ['download-electron', 'shell:app-apm-install'])
+  grunt.registerTask('build', ['grunt-download-electron', 'shell:app-apm-install', 'copy:app', 'generate-plist'])

--- a/package.json
+++ b/package.json
@@ -4,16 +4,17 @@
   "application": {
     "name": "Kart"
   },
-  "atomShellVersion": "0.17.2",
+  "atomShellVersion": "0.33.0",
   "devDependencies": {
-    "grunt-download-atom-shell": "0.7.0",
-    "fs-plus": "2.x",
     "formidable": "~1.0.14",
+    "fs-plus": "2.x",
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.9",
+    "grunt-contrib-copy": "~0.5",
+    "grunt-download-atom-shell": "0.7.0",
+    "grunt-download-electron": "^2.1.2",
     "grunt-shell": "~0.3.1",
     "grunt-symbolic-link": "~0.3.1",
-    "grunt-contrib-copy": "~0.5",
     "request": "~2.27.0",
     "walkdir": "0.0.7"
   }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,6 +3,6 @@
 cd "$(dirname "${BASH_SOURCE[0]}" )/.."
 export APP_VERSION=`cat VERSION`
 apm install
-npm install grunt-download-atom-shell
+npm install grunt-download-electron
 rm -r atom-shell
 grunt bootstrap

--- a/script/bootstrap.ps1
+++ b/script/bootstrap.ps1
@@ -1,5 +1,5 @@
 $version = Get-Content VERSION
 $env:APP_VERSION = $version
 & apm install
-& npm install grunt-download-atom-shell
+& npm install grunt-download-electron
 & grunt bootstrap-win

--- a/script/run
+++ b/script/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-open "./atom-shell/`ls atom-shell/ | grep app`" --args --dev "$@"
+open "./electron/`ls electron/ | grep app`" --args --dev "$@"

--- a/script/run.ps1
+++ b/script/run.ps1
@@ -1,3 +1,3 @@
 $appPath = Resolve-Path app
 $args = @("--dev", "--", $appPath)
-Start-Process -FilePath .\atom-shell\atom.exe -ArgumentList $args
+Start-Process -FilePath electron -ArgumentList $args


### PR DESCRIPTION
This project would not work correctly using the 'download-atom-shell'
task. After poking around NPM, I found a 'download-electron' task that
works the same and actually started up on the system. Files were changed
to match.
